### PR TITLE
add basic test-kitchen config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,44 @@
+---
+driver:
+  name: docker
+  use_sudo: false
+
+provisioner:
+  name: chef_zero
+
+verifier:
+  name: inspec
+
+platforms:
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu:12.04
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu:14.04
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+- name: centos-6.6
+  driver:
+    image: centos:6.6
+- name: centos-6.7
+  driver:
+    image: centos:6.7
+- name: centos-7
+  driver:
+    image: centos:7
+    privileged: true
+    run_command: /usr/sbin/init
+- name: debian-7
+  driver:
+    image: debian:7
+- name: debian-8
+  driver:
+    image: debian:8
+
+suites:
+  - name: default
+    verifier:
+      inspec_tests:
+        - path: .

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,9 +25,17 @@ platforms:
 - name: centos-6.7
   driver:
     image: centos:6.7
+- name: centos-6.8
+  driver:
+    image: centos:6.8
 - name: centos-7
   driver:
     image: centos:7
+    privileged: true
+    run_command: /usr/sbin/init
+- name: centos-7.2
+  driver:
+    image: centos:7.2.1511
     privileged: true
     run_command: /usr/sbin/init
 - name: debian-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+language: ruby
+cache: bundler
+rvm:
+  - 2.0
+  - 2.2
+  - 2.3.1
+
+bundler_args: --without integration
+script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rack', '1.6.4'
+gem 'inspec', '~> 1'
+gem 'rubocop', '~> 0.44.0'
+gem 'highline', '~> 1.6.0'
+
+group :integration do
+  gem 'berkshelf'
+  gem 'kitchen-inspec'
+  gem 'test-kitchen'
+  gem 'kitchen-docker'
+end
+
+group :tools do
+  gem 'github_changelog_generator', '~> 1.12.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,38 @@
+#!/usr/bin/env rake
+
+require 'rake/testtask'
+require 'rubocop/rake_task'
+
+# Rubocop
+desc 'Run Rubocop lint checks'
+task :rubocop do
+  RuboCop::RakeTask.new
+end
+
+# lint the project
+desc 'Run robocop linter'
+task lint: [:rubocop]
+
+# run tests
+task default: [:lint, 'test:check']
+
+namespace :test do
+  # run inspec check to verify that the profile is properly configured
+  task :check do
+    dir = File.join(File.dirname(__FILE__))
+    sh("bundle exec inspec check #{dir}")
+  end
+end
+
+# Automatically generate a changelog for this project. Only loaded if
+# the necessary gem is installed.
+# use `rake changelog to=1.2.0`
+begin
+  v = ENV['to']
+  require 'github_changelog_generator/task'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.future_release = v
+  end
+rescue LoadError
+  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
+end


### PR DESCRIPTION
This PR adds test-kitchen support to verify that this profile works as expected.

TODO:
- enable travis
- enable kitchen verify in test-kitchen
- errors in test kitchen verify are not an error for this profile, because they reflect a finding
- we need to inspect the inspec report
- add rubocop